### PR TITLE
📦️ Update the package version to `1.1.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openreachtech/mentsu-rootpath",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openreachtech/mentsu-rootpath",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openreachtech/eslint-config": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openreachtech/mentsu-rootpath",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Resolve root path in ECMAScript Modules",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Bump the package version from `1.1.1` to `1.1.2`, in `package.json` and in the two version fields of `package-lock.json`, ahead of publishing to npmjs.

Close #52