### PR TITLE
⚙️ Sync GitHub workflows

### DIFF
--- a/.github/workflows/fill-publish-version.yml
+++ b/.github/workflows/fill-publish-version.yml
@@ -1,0 +1,82 @@
+name: Fill publish version
+
+# When a publish issue is opened, extract the version from its title
+# (e.g. "🚀 Publish `1.2.0`") and replace every `vvvvvv` placeholder in the
+# title and body with it.
+#
+# NOTE: GitHub Actions run per-repository. Distribute this workflow to every
+# managed repository (it does not propagate from the org .github repo on its own).
+#
+# NOTE: This workflow must work on both GitHub-hosted and self-hosted runners.
+# A self-hosted runner cannot be assumed to have gh or Python installed, so use
+# actions/github-script rather than depend on a binary being on PATH.
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  fill:
+    if: startsWith(github.event.issue.title, '🚀 Publish')
+
+    # private repository: self-hosted
+    # public repository: github-hosted
+    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted", "light"]' || '["ubuntu-latest"]') }}
+
+    timeout-minutes: 5
+
+    steps:
+      - name: 🤖 Replace vvvvvv with the version in the title
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            /*
+             * Read the issue live. context.payload holds a snapshot taken when
+             * the event fired, and writing that back reverts any edit made
+             * while this runs.
+             */
+            const { data: issue } = await github.rest.issues.get({
+              ...context.repo,
+              issue_number: context.issue.number,
+            })
+
+            const body = issue.body ?? ''
+
+            /*
+             * Nothing left to fill. Without this, every later edit would
+             * rewrite the body from the copy read above.
+             */
+            if (!issue.title.includes('vvvvvv') && !body.includes('vvvvvv')) {
+              core.info('No vvvvvv placeholder left; skipping.')
+
+              return
+            }
+
+            /*
+             * The version lives in the backticks after `Publish`, and must be a
+             * bare x.x.x. Since npm strips build metadata and leading zeros on
+             * publish, those forms would tag a version never published.
+             */
+            const matchResult = issue.title.match(/Publish `((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))`/u)
+
+            const [
+              ,
+              version = null,
+            ] = matchResult ?? []
+
+            if (!version) {
+              core.info("No version found in the title (still 'vvvvvv'?); skipping.")
+
+              return
+            }
+            core.info(`Filling version: ${version}`)
+
+            await github.rest.issues.update({
+              ...context.repo,
+              issue_number: issue.number,
+              title: issue.title.replaceAll('vvvvvv', version),
+              body: body.replaceAll('vvvvvv', version),
+            })

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -1,0 +1,39 @@
+name: Main Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  main-guard:
+    name: Main Guard
+
+    # private repository: self-hosted
+    # public repository: github-hosted
+    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted", "light"]' || '["ubuntu-latest"]') }}
+
+    timeout-minutes: 5
+
+    steps:
+      - name: Validate source branch name
+        shell: bash
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          case "$HEAD_REF" in
+            release/*|hotfix/*|dev|env)
+              echo "Source branch '$HEAD_REF' is allowed."
+              ;;
+            *)
+              echo "::error::Only 'release/*', 'hotfix/*', 'dev', and 'env' branches may be merged into 'main'. (❌ '$HEAD_REF' is not allowed)"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,106 +1,126 @@
 name: Create Semantic Version Tag and Release
 
+# When a pull request into main is merged, tag its merge commit with the version
+# in the title ("Release > Main as `x.x.x`") and publish a GitHub Release.
+#
+# NOTE: This workflow must work on both GitHub-hosted and self-hosted runners.
+# A self-hosted runner cannot be assumed to have gh or Python installed, so use
+# actions/github-script rather than depend on a binary being on PATH.
+
 on:
   pull_request:
     types: [closed]
     branches:
       - main
 
+# ⚠️ Don't add concurrency: here, because cancelling a run between the tag and
+# the release would leave the tag without one. Each merge runs once and is never
+# rerun, so there is nothing for a group to protect.
+
+# Required to create the tag and the release.
+permissions:
+  contents: write
+
 jobs:
   tag-and-release:
     # Only run when PR is merged
     if: github.event.pull_request.merged == true
 
-    runs-on: ubuntu-latest
+    # private repository: self-hosted
+    # public repository: github-hosted
+    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted", "light"]' || '["ubuntu-latest"]') }}
+
+    timeout-minutes: 5
 
     steps:
-      - name: 🛎 Checkout code
-        uses: actions/checkout@v4
+      - name: ✂️ Extract the version from the PR title, or the release branch name
+        id: extract_version
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          fetch-depth: 0
+          script: |
+            /*
+             * Publishing targets npmjs, so only a bare x.x.x is accepted.
+             */
+            const CORE = /(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)/u.source
+            const pullRequest = context.payload.pull_request
 
-      - name: ✅️ Get latest tag
-        id: get_latest_tag
-        run: |
-          # Get the latest semantic version tag
-          LATEST_TAG=$(git tag -l "[0-9]*.[0-9]*.[0-9]*" | sort -V | tail -n 1)
-          if [ -z "$LATEST_TAG" ]; then
-            LATEST_TAG="0.0.0"
-          fi
-          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
-          echo "Latest tag: $LATEST_TAG"
+            const titleMatch = pullRequest.title.match(new RegExp(`\`(${CORE})\``, 'u'))
 
-      - name: ✅️ Determine version bump type from PR title
-        id: bump_type
-        run: |
-          PR_TITLE=$(echo '${{ github.event.pull_request.title }}' | sed 's/`/\\`/g')
+            const [
+              ,
+              titleVersion = null,
+            ] = titleMatch ?? []
 
-          # Default to patch
-          echo "bump=none" >> $GITHUB_OUTPUT
-          echo "Bumping none (default)"
+            /*
+             * Fallback: a release/x.x.x branch name.
+             */
+            const branchMatch = pullRequest.head.ref.match(new RegExp(`^release/(${CORE})$`, 'u'))
 
-          if [[ "$PR_TITLE" == *"[patch]"* ]]; then
-            echo "bump=patch" >> $GITHUB_OUTPUT
-            echo "Bumping patch version (from PR title)"
-          fi
+            const [
+              ,
+              branchVersion = null,
+            ] = branchMatch ?? []
 
-          if [[ "$PR_TITLE" == *"[major]"* ]]; then
-            echo "bump=major" >> $GITHUB_OUTPUT
-            echo "Bumping major version (from PR title)"
-          fi
+            /*
+             * Both names carry the version, and both are typed by hand. Two
+             * sources of one value are worth nothing unless they must agree, so
+             * a disagreement stops the run instead of picking a winner.
+             */
+            if (titleVersion && branchVersion && titleVersion !== branchVersion) {
+              core.setFailed(`Version mismatch: title \`${titleVersion}\` vs branch \`${branchVersion}\`.`)
 
-          if [[ "$PR_TITLE" == *"[minor]"* ]]; then
-            echo "bump=minor" >> $GITHUB_OUTPUT
-            echo "Bumping minor version (from PR title)"
-          fi
+              return
+            }
 
-      - name: ✅️ Bump version
-        id: bump_version
-        run: |
-          # Get current version
-          CURRENT_VERSION=${{ steps.get_latest_tag.outputs.latest_tag }}
+            const version = titleVersion ?? branchVersion
 
-          # Split version into components
-          MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
-          MINOR=$(echo $CURRENT_VERSION | cut -d. -f2)
-          PATCH=$(echo $CURRENT_VERSION | cut -d. -f3)
+            if (version) {
+              core.info(`Version: ${version}`)
+            } else {
+              core.info('No version found in the PR title or the branch name. Skipping the tag and release.')
+            }
 
-          # Initialize
-          NEW_VERSION="$((MAJOR + 0)).$((MINOR + 0)).$((PATCH + 0))"
+            core.setOutput('version', version)
 
-          # Override if specified
-          if [ "${{ steps.bump_type.outputs.bump }}" == "patch" ]; then
-            NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
-          fi
+      - name: 🏷️ Create the version tag
+        if: steps.extract_version.outputs.version != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          VERSION: ${{ steps.extract_version.outputs.version }}
+        with:
+          script: |
+            const { VERSION } = process.env
 
-          if [ "${{ steps.bump_type.outputs.bump }}" == "minor" ]; then
-            NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
-          fi
-
-          if [ "${{ steps.bump_type.outputs.bump }}" == "major" ]; then
-            NEW_VERSION="$((MAJOR + 1)).0.0"
-          fi
-
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "New version: $NEW_VERSION"
-
-      - name: 🏷️ Create new version tag
-        run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
-
-          NEW_TAG=${{ steps.bump_version.outputs.new_version }}
-          git tag $NEW_TAG
-          git push origin $NEW_TAG
-          echo "Created and pushed tag: $NEW_TAG"
+            /*
+             * Every failure here is a real one, so none is caught. A tag that
+             * is already there means the version was released before, which is
+             * a title left unbumped rather than a state to skip over.
+             */
+            await github.rest.git
+              .createRef({
+                ...context.repo,
+                ref: `refs/tags/${VERSION}`,
+                sha: context.payload.pull_request.merge_commit_sha,
+              })
 
       - name: 📢 Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ steps.bump_version.outputs.new_version }}
-          name: ${{ steps.bump_version.outputs.new_version }}
-          draft: false
-          prerelease: false
-          generate_release_notes: true
+        if: steps.extract_version.outputs.version != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.extract_version.outputs.version }}
+        with:
+          script: |
+            const { VERSION } = process.env
+
+            /*
+             * A step condition carrying no status function still requires every
+             * earlier step to have succeeded, so this runs only once the tag is
+             * in place and needs no guard of its own.
+             */
+            await github.rest.repos
+              .createRelease({
+                ...context.repo,
+                tag_name: VERSION,
+                name: VERSION,
+                generate_release_notes: true,
+              })


### PR DESCRIPTION
# Why

* Close #58

# How

* Brings `.github/workflows/` to what `npm-boilerplate` holds on `main`, before `release/1.1.2` is merged into `main`. `main-guard.yml` is the one that matters most here: without it, any branch could reach `main`
* `test.yml` is deliberately left out. Syncing it drops the GitHub-Packages token, and a devDependency here is pinned to a version that exists only on that registry — the bump that fixes it changes `package.json`, which does ship in the tarball. That pair belongs to the next release line
* Only `.github/` is touched, and it is not in the published tarball — so `1.1.2` keeps producing exactly what npm already holds, and this needs no version of its own
