### PR TITLE
📄 Kick out concerning npmrc from README files

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -13,16 +13,6 @@ Node.jsが必要です。まだインストールされていない場合は、�
 | Node.js | ^20.14.0 |
 | npm | ^10.9.2 |
 
-## `.npmrc` のセットアップ
-
-プロジェクトのルートディレクトリに `.npmrc` ファイルを作成し、必要な設定を追加してください。
-
-`.npmrc` ファイルに以下の行を追加してください。
-
-```
-@openreachtech:registry=https://npm.pkg.github.com
-```
-
 ## コマンド
 
 以下のコマンドで `mentsu-rootpath` をインストールできます：

--- a/README.md
+++ b/README.md
@@ -13,16 +13,6 @@ Node.js is required. If you haven't installed it yet, please install it first.
 | Node.js | ^20.14.0 |
 | npm | ^10.9.2 |
 
-## Setting up `.npmrc`
-
-Create a `.npmrc` file in your project's root directory and add the necessary settings.
-
-Add the following line to your `.npmrc` file:
-
-```
-@openreachtech:registry=https://npm.pkg.github.com
-```
-
 ## Command
 
 You can install `mentsu-rootpath` with the following command:


### PR DESCRIPTION
# Why

* Close #66

# How

* This package is on npmjs, so a consumer needs no registry line and no `npm login`. The step told them to point the `@openreachtech` scope at GitHub Packages, where the newer versions are not published
* The README ships inside the tarball, so the wrong instruction reaches everyone who installs the package
