### PR TITLE
📦️ Update the package version to `1.1.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openreachtech/mentsu-rootpath",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openreachtech/mentsu-rootpath",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openreachtech/eslint-config": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openreachtech/mentsu-rootpath",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Resolve root path in ECMAScript Modules",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
# Why

* Close #68

# How

* Raises the version from `1.1.2` to `1.1.3`, the version of this release line
* Nothing else is left on it: `test.yml` is synced, `eslint-config` is at `4.5.0`, and the README no longer asks for a GitHub Packages registry
